### PR TITLE
Update Brew on setup

### DIFF
--- a/setup_osx.sh
+++ b/setup_osx.sh
@@ -37,6 +37,9 @@ killall Dock
 # Install Homebrew
 ruby -e "$(curl -fsSL https://raw.github.com/Homebrew/homebrew/go/install)"
 
+# Update Brew in case it was already installed and not up to date
+brew update
+
 # Install basics
 brew install vim git nodejs wget curl htop gist zsh
 


### PR DESCRIPTION
In the event that a machine already has brew installed, but it is not up to date you can ensure that brew has the latest catalog. The new install script doesn't update if it is already installed automatically.

I ran into an issue when playing with your dotfiles where this was the case, and it did not update to show the latest version of vim, and YouCompleteMe would not install, etc.

This fixes that issue.
